### PR TITLE
Support POSIX basename() from musl libc

### DIFF
--- a/log.c
+++ b/log.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <libgen.h>
 
 #include "log.h"
 
@@ -65,6 +66,7 @@ void ___log(const char *filename, int line, int priority, const char *fmt, ...)
 {
     char new_fmt[256];
     va_list ap;
+    char *dirc = NULL;
 
     priority = LOG_PRI(priority);
 
@@ -72,9 +74,13 @@ void ___log(const char *filename, int line, int priority, const char *fmt, ...)
         return;
 
     if (__log_flags__ & LOG_FLAG_FILE || __log_flags__ & LOG_FLAG_PATH) {
-        if (!(__log_flags__ & LOG_FLAG_PATH))
-            filename = basename(filename);
+        if (!(__log_flags__ & LOG_FLAG_PATH)) {
+            dirc = strdup(filename);
+            filename = basename(dirc);
+        }
         snprintf(new_fmt, sizeof(new_fmt), "(%s:%3d) %s", filename, line, fmt);
+        if (!(__log_flags__ & LOG_FLAG_PATH))
+            free(dirc);
     } else {
         snprintf(new_fmt, sizeof(new_fmt), "%s", fmt);
     }


### PR DESCRIPTION
Musl libc 1.2.5 removed the definition of the basename() function from string.h and only provides it in libgen.h as the POSIX standard defines it.

This change fixes compilation with musl libc 1.2.5.
````
/build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c: In function '___log':
/build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c:76:24: error: implicit declaration of function 'basename' [-Werror=implicit-function-declaration]
   76 |             filename = basename(filename);
      |                        ^~~~~~~~
/build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c:76:22: error: assignment to 'const char *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
   76 |             filename = basename(filename);
      |                      ^
````

basename() modifies the input string, copy it first with strdup(), If strdup() returns NULL the code will handle it.